### PR TITLE
fix bulkrepair custom export path

### DIFF
--- a/aacrepair/__init__.py
+++ b/aacrepair/__init__.py
@@ -183,7 +183,7 @@ class AacRepair:
         """
         file_full_name = "buf.aac"
 
-        if type(chunk) != bytes:
+        if type(chunk) is not bytes:
             chunk = self.convert_file_like_object(chunk)
             if not chunk:
                 return False

--- a/aacrepair/cmd.py
+++ b/aacrepair/cmd.py
@@ -81,7 +81,7 @@ def prepare_path_run_write_bulk(aac_path):
     export_path = path_list[1] if len(path_list) > 1 else None
     if pathlib.Path(default_path).is_dir():
         if export_path:
-            instance_repair_bulk(default_path, export_path=True)
+            instance_repair_bulk(default_path, export_path=export_path)
         else:
             instance_repair_bulk(default_path)
         print(f'{exit_msg}')


### PR DESCRIPTION
fix also E721 do not compare types, for exact checks use `is` / `is not` in __init__.py 
compare, val is ==
instance, isinstance()
types, is; is not